### PR TITLE
Fix: Update replay saving logic for bhoptimer v4.0.0 compatibility

### DIFF
--- a/scripting/shavit-myreplay.sp
+++ b/scripting/shavit-myreplay.sp
@@ -50,7 +50,7 @@ public Plugin myinfo =
     name        = "shavit - Personal Replays",
     author      = "BoomShot",
     description = "Allows a user to watch their replay after finishing the map.",
-    version     = "1.0.4",
+    version     = "1.0.5",
     url         = "https://github.com/BoomShotKapow/shavit-myreplay"
 };
 


### PR DESCRIPTION
Replaces `Shavit_ShouldSaveReplayCopy` with `Shavit_AddAdditionalReplayPathsHere` and updates `Shavit_OnReplaySaved` to match the new replay recorder API requirements in bhoptimer v4.0.0. Changes:
- Replaced `Shavit_ShouldSaveReplayCopy` with `Shavit_AddAdditionalReplayPathsHere`.
- Updated `Shavit_OnReplaySaved` signature and implementation to handle `replaypaths` ArrayList.
- Removed unused `CopyReplayFile` function.
- Added `Shavit_AlsoSaveReplayTo` native declaration.